### PR TITLE
Update alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.7
 
 RUN apk add --update --no-cache \
     curl \


### PR DESCRIPTION
This will update alpine to the latest version which comes with fresh aws-cli. It till also update `ecs-deploy` script to the latest master.

Not sure which update fixes such deployment failure on FARGATE:
 ```
An error occurred (ClientException) when calling the RegisterTaskDefinition operation: Invalid setting for container 'logstash'. At least one of 'memory' or 'memoryReservation' must be specified.
```
but it works now.