### PR TITLE
Update to newest version of ecs-deploy and add support for --tag-only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,4 @@
-FROM alpine:3.5
-
-RUN apk add --update --no-cache \
-    curl \
-    jq \
-    ca-certificates \
-    bash \
-    python \
-    && python -m ensurepip \
-    && rm -r /usr/lib/python*/ensurepip \
-    && pip install --upgrade pip setuptools \
-    awscli --ignore-installed \
-    && rm -r /root/.cache
-
-RUN curl https://raw.githubusercontent.com/silinternational/ecs-deploy/master/ecs-deploy -o /bin/ecs-deploy \
-    && chmod +x /bin/ecs-deploy
+FROM silintl/ecs-deploy:3.9.1
 
 COPY update.sh /bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,4 @@ FROM silintl/ecs-deploy:3.9.1
 
 COPY update.sh /bin/
 
-ENTRYPOINT ["/bin/bash"]
-
-CMD ["/bin/update.sh"]
+ENTRYPOINT ["/bin/bash", "-l", "-c", "/bin/update.sh"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Another example with optional variables
       aws_secret_access_key: vdfklmnopenxasweiqokdvdfjeqwuioenajks # optional, better to use as secret
 ```
 
+Alternatively, the `image_tag` parameter can be used to deploy a specific container image version, instead of latest
+
+```yaml
+  pipeline:
+    deploy:
+      image: joshdvir/drone-ecs-deploy
+      cluster: my-cluster
+      service: my-service
+      image_tag: v123
+      aws_region: us-east-1
+```
+
+Optional variables can be applied in the same way as the `image:latest` example, however `image_name` is not required.
+
 ## Optional secrets
 
 * AWS_ACCESS_KEY_ID

--- a/update.sh
+++ b/update.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 if [ -z ${PLUGIN_CLUSTER} ]; then
-  echo "missing cluster"
+  echo "missing required parameter cluster"
   exit 1
 fi
 
-if [ -z ${PLUGIN_IMAGE_NAME} ]; then
-  echo "missing image"
+if [ -z ${PLUGIN_IMAGE_NAME} ] && [ -z ${PLUGIN_IMAGE_TAG} ]; then
+  echo "either image name or image tag parameter is required"
   exit 1
 fi
 
 if [ -z ${PLUGIN_SERVICE} ]; then
-  echo "missing Service"
+  echo "missing required parameter service"
   exit 1
 fi
 
@@ -39,4 +39,9 @@ if [ ! -z ${PLUGIN_AWS_SECRET_ACCESS_KEY} ]; then
   AWS_SECRET_ACCESS_KEY=$PLUGIN_AWS_SECRET_ACCESS_KEY
 fi
 
-ecs-deploy --region ${PLUGIN_AWS_REGION} --cluster ${PLUGIN_CLUSTER} --image ${PLUGIN_IMAGE_NAME} --service-name ${PLUGIN_SERVICE} --timeout ${PLUGIN_TIMEOUT} --min ${PLUGIN_MIN} --max ${PLUGIN_MAX}
+if [ ! -z ${PLUGIN_IMAGE_TAG} ]; then
+  # ecs-deploy base container puts the script in the fs root :(
+  /ecs-deploy --region ${PLUGIN_AWS_REGION} --cluster ${PLUGIN_CLUSTER} --tag-only ${PLUGIN_IMAGE_TAG} --image ignore --service-name ${PLUGIN_SERVICE} --timeout ${PLUGIN_TIMEOUT} --min ${PLUGIN_MIN} --max ${PLUGIN_MAX}
+else
+  /ecs-deploy --region ${PLUGIN_AWS_REGION} --cluster ${PLUGIN_CLUSTER} --image ${PLUGIN_IMAGE_NAME} --service-name ${PLUGIN_SERVICE} --timeout ${PLUGIN_TIMEOUT} --min ${PLUGIN_MIN} --max ${PLUGIN_MAX}
+fi


### PR DESCRIPTION
There's a few things in this PR:

- Replace the base container with the container published by ecs-deploy - the Dockerfile for this repo becomes much simpler
- Update ecs-deploy to the latest version (3.9.1 - Aug 2020)
- Add support for ecs-deploy --tag-only option instead of always using the `:latest` tag
- Update readme to show new example of using tag-only option