### PR TITLE
Add support for propagating ECS task definition tags via task_definition_tags option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Another example with optional variables
       min: "100" # defaults to 100
       aws_access_key_id: ewijdfmvbasciosvdfkl # optional, better to use as secret
       aws_secret_access_key: vdfklmnopenxasweiqokdvdfjeqwuioenajks # optional, better to use as secret
+      task_definition_tags: true # optional, set to true to propagate tags from the existing task definition to the new task definition revision
 ```
 
 Alternatively, the `image_tag` parameter can be used to deploy a specific container image version, instead of latest

--- a/update.sh
+++ b/update.sh
@@ -27,6 +27,11 @@ if [ -z ${PLUGIN_MAX} ]; then
   PLUGIN_MAX="200"
 fi
 
+COPY_TAGS_FLAG=""
+if [ "${PLUGIN_TASK_DEFINITION_TAGS}" = "true" ]; then
+  COPY_TAGS_FLAG="--copy-task-definition-tags"
+fi
+
 if [ -z ${PLUGIN_MIN} ]; then
   PLUGIN_MIN="100"
 fi
@@ -41,7 +46,7 @@ fi
 
 if [ ! -z ${PLUGIN_IMAGE_TAG} ]; then
   # ecs-deploy base container puts the script in the fs root :(
-  /ecs-deploy --region ${PLUGIN_AWS_REGION} --cluster ${PLUGIN_CLUSTER} --tag-only ${PLUGIN_IMAGE_TAG} --image ignore --service-name ${PLUGIN_SERVICE} --timeout ${PLUGIN_TIMEOUT} --min ${PLUGIN_MIN} --max ${PLUGIN_MAX}
+  /ecs-deploy --region ${PLUGIN_AWS_REGION} --cluster ${PLUGIN_CLUSTER} --tag-only ${PLUGIN_IMAGE_TAG} --image ignore --service-name ${PLUGIN_SERVICE} --timeout ${PLUGIN_TIMEOUT} --min ${PLUGIN_MIN} --max ${PLUGIN_MAX} ${COPY_TAGS_FLAG}
 else
-  /ecs-deploy --region ${PLUGIN_AWS_REGION} --cluster ${PLUGIN_CLUSTER} --image ${PLUGIN_IMAGE_NAME} --service-name ${PLUGIN_SERVICE} --timeout ${PLUGIN_TIMEOUT} --min ${PLUGIN_MIN} --max ${PLUGIN_MAX}
+  /ecs-deploy --region ${PLUGIN_AWS_REGION} --cluster ${PLUGIN_CLUSTER} --image ${PLUGIN_IMAGE_NAME} --service-name ${PLUGIN_SERVICE} --timeout ${PLUGIN_TIMEOUT} --min ${PLUGIN_MIN} --max ${PLUGIN_MAX} ${COPY_TAGS_FLAG}
 fi


### PR DESCRIPTION
<html><head></head><body><hr><h2><strong>PR Title</strong></h2><pre><code>Add support for propagating ECS task definition tags via task_definition_tags option
</code></pre><hr><h2><strong>PR Description</strong></h2><h3>Summary</h3><p>This PR adds support for propagating tags from the existing ECS task definition to newly registered task definition revisions.</p><p>The change introduces a new optional plugin parameter, <code inline="">task_definition_tags</code>, which conditionally passes the <code inline="">--copy-task-definition-tags</code> flag to <code inline="">ecs-deploy</code>.</p><hr><h3>Details</h3><ul><li><p>When <code inline="">task_definition_tags=true</code>, the plugin passes <code inline="">--copy-task-definition-tags</code> to <code inline="">ecs-deploy</code>, enabling tag propagation.</p></li><li><p>When <code inline="">false</code> or unset, the flag is omitted and no tags are copied.</p></li><li><p>This aligns with <code inline="">ecs-deploy</code>’s presence-only flag semantics and avoids unintended behavior.</p></li></ul><hr><h3>Example usage</h3><pre><code class="language-yaml">task_definition_tags: true
</code></pre><hr><h3>Behavior</h3>
task_definition_tags | Tags propagated
-- | --
true | ✅ Yes
false | ❌ No
unset | ❌ No

<hr><h3>Backward compatibility</h3><ul><li><p>Fully backward compatible</p></li><li><p>Existing pipelines are unaffected unless the new option is explicitly enabled</p></li></ul><hr><h3>Motivation</h3><p>Propagating task definition tags helps maintain consistency across ECS deployments and simplifies cost allocation, auditing, and resource management.</body></html>